### PR TITLE
Move open methods of container cells to an extension

### DIFF
--- a/Sources/Basic/ContainerCollectionViewCell.swift
+++ b/Sources/Basic/ContainerCollectionViewCell.swift
@@ -62,8 +62,11 @@ open class ContainerCollectionViewCell<ContentView: StatefulViewProtocol>: UICol
         super.prepareForReuse()
 
         view.model = .default
+        didChangeModel()
     }
+}
 
+extension ContainerCollectionViewCell {
     /// This method is intended to be overridden by a subclass to perform setup after the initialization of the cell.
     ///
     /// - Attention: Always ensure calling `super.viewDidLoad()` to avoid unexpected behaviour.

--- a/Sources/Basic/ContainerTableViewCell.swift
+++ b/Sources/Basic/ContainerTableViewCell.swift
@@ -81,9 +81,12 @@ open class ContainerTableViewCell<ContentView: StatefulViewProtocol>: UITableVie
     open override func prepareForReuse() {
         super.prepareForReuse()
 
-        model = .default
+        view.model = .default
+        didChangeModel()
     }
+}
 
+extension ContainerTableViewCell {
     /// This method is intended to be overridden by a subclass to perform setup after the initialization of the cell.
     ///
     /// - Attention: Always ensure calling `super.viewDidLoad()` to avoid unexpected behaviour.


### PR DESCRIPTION
The Swift Runtime is crashing for unknown reason when `-viewDidLoad` or `-didChangeModel` are called. It seems that the generic types are getting lost so that the compiler doesn't know which implementation of the functions has to be called. By moving the open methods to an extension the compiler takes them as fallback functions for any kind of generic type signature of the classes.