### PR TITLE
Make ListViewController open to be able to subclass it

### DIFF
--- a/Sources/Container/List/ListViewController.swift
+++ b/Sources/Container/List/ListViewController.swift
@@ -22,7 +22,7 @@ import UIKit
 /// let fruitListViewController: FruitListViewController = .instantiate()
 /// fruitListViewController.model = .init(items: [FruitViewModel(...), ...])
 /// ```
-public final class ListViewController<View: StatefulViewProtocol>: StatefulViewController<ListViewModel<View.Model>>, UITableViewDataSource {
+open class ListViewController<View: StatefulViewProtocol>: StatefulViewController<ListViewModel<View.Model>>, UITableViewDataSource {
     private final class ListTableViewCell: ContainerTableViewCell<View> {}
 
     /// The content table view of the `ListViewController`.

--- a/Sources/Container/List/ListViewController.swift
+++ b/Sources/Container/List/ListViewController.swift
@@ -28,18 +28,18 @@ open class ListViewController<View: StatefulViewProtocol>: StatefulViewControlle
     /// The content table view of the `ListViewController`.
     public private(set) lazy var tableView: UITableView = .init(frame: .zero, style: .plain)
 
-    public override func loadView() {
+    open override func loadView() {
         view = tableView
     }
 
-    public override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
 
         tableView.dataSource = self
         tableView.register(cellOfType: ListTableViewCell.self)
     }
 
-    public override func didChangeModel() {
+    open override func didChangeModel() {
         super.didChangeModel()
 
         switch model.height {


### PR DESCRIPTION
# Description
As we are currently developing a sample application we want to use all of the components within JamitFoundation we found an issue that the `ListViewController` cannot be subclassed but should be.