### PR TITLE
Add TableViewHeaderFooterView Container and recycling extension

### DIFF
--- a/Sources/Basic/ContainerTableViewHeaderFooterView.swift
+++ b/Sources/Basic/ContainerTableViewHeaderFooterView.swift
@@ -1,0 +1,89 @@
+import Foundation
+import UIKit
+
+/// A container class enabling the possibility to embed views conforming to `StatefulViewProtocol`
+/// into a `UITableViewController` as reusable headerFooterView.
+///
+/// Example:
+///
+/// ```swift
+/// // Defined some where in the code base...
+/// final class MyView: StatefulView<MyViewModel> {
+///     // ...
+/// }
+///
+/// // Making `MyView` embeddable as reusable table view headerFooterView...
+/// final class MyHeaderFooterView: ContainerTableViewHeaderFooterView<MyView> {}
+/// ```
+open class ContainerTableViewHeaderFooterView<ContentView: StatefulViewProtocol>: TableViewHeaderFooterView {
+    /// A flag controlling the dynamic resizing behaviour of the embedded view.
+    ///
+    /// If `isDynamicallyResizable` returns true, then the `view` will be resizable without breaking constraints.
+    class var isDynamicallyResizable: Bool { return false }
+
+    /// The underlying view which is embedded into the `contentView`.
+    private(set) lazy var view: ContentView = .instantiate()
+
+    private lazy var topConstraint: NSLayoutConstraint = view.topAnchor.constraint(equalTo: contentView.topAnchor)
+    private lazy var leadingConstraint: NSLayoutConstraint = view.leadingAnchor.constraint(equalTo: contentView.leadingAnchor)
+    private lazy var trailingConstraint: NSLayoutConstraint = view.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+    private lazy var bottomConstraint: NSLayoutConstraint = contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+
+    /// The current state of the underlying view.
+    public var model: ContentView.Model {
+        get { return view.model }
+        set {
+            view.model = newValue
+            perform(#selector(didChangeModel))
+        }
+    }
+
+    /// The custom disance that the contentView is inset from the background view.
+    public var contentInset: UIEdgeInsets = .zero {
+        didSet {
+            topConstraint.constant = contentInset.top
+            leadingConstraint.constant = contentInset.left
+            trailingConstraint.constant = contentInset.right
+            bottomConstraint.constant = contentInset.bottom
+        }
+    }
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+
+        defaultInit()
+        perform(#selector(viewDidLoad))
+    }
+
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        defaultInit()
+    }
+
+    override open func awakeFromNib() {
+        super.awakeFromNib()
+
+        perform(#selector(viewDidLoad))
+    }
+
+    private func defaultInit() {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(view)
+
+        // NOTE: Setting the priority of bottomConstraint to low avoids unsatisfiable constraints issues in UITableView
+        if type(of: self).isDynamicallyResizable {
+            bottomConstraint.priority = .defaultLow
+        }
+
+        [topConstraint, leadingConstraint, trailingConstraint, bottomConstraint].forEach { $0.isActive = true }
+    }
+
+    override open func prepareForReuse() {
+        super.prepareForReuse()
+
+        view.model = .default
+        perform(#selector(didChangeModel))
+    }
+}
+

--- a/Sources/Basic/TableViewHeaderFooterView.swift
+++ b/Sources/Basic/TableViewHeaderFooterView.swift
@@ -1,0 +1,16 @@
+import Foundation
+import UIKit
+
+/// The base class to be used for custom table view headerFooterView.
+@objc
+open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
+    /// This method is intended to be overridden by a subclass to perform setup after the initialization of the headerFooterView.
+    ///
+    /// - Attention: Always ensure calling `super.viewDidLoad()` to avoid unexpected behaviour.
+    @objc open func viewDidLoad() {}
+
+    /// This method is intended to be overridden by a subclass to listen for state changes.
+    ///
+    /// - Attention: Always ensure calling `super.didChangeModel()` to avoid unexpected behaviour.
+    @objc open func didChangeModel() {}
+}

--- a/Sources/Extension/UITableView+recycling.swift
+++ b/Sources/Extension/UITableView+recycling.swift
@@ -26,6 +26,29 @@ public extension UITableView {
         }
     }
 
+    /// Registers a reusable table view headerFooterView of type `HeaderFooterViewType` which inherits from `UITableViewHeaderFooterView`.
+    ///
+    /// The reusable headerFooterView will be registered as nib when there is a nib file inside the given Bundle
+    /// which has the same name as the class name of `HeaderFooterViewType`.
+    ///
+    /// The reuse identifier of the headerFooterView will be the class name of `HeaderFooterViewType`.
+    ///
+    /// Example:
+    ///
+    /// ```swift
+    /// tableView.register(headerFooterViewOfType: MyHeaderFooterView.self)
+    /// ```
+    ///
+    /// - Parameter headerFooterViewOfType: The type of the reusable headerFooterView to register.
+    func register<HeaderFooterViewType: UITableViewHeaderFooterView>(headerFooterViewOfType headerFooterViewType: HeaderFooterViewType.Type) {
+        let identifier = String(describing: headerFooterViewType)
+        if Bundle.main.path(forResource: identifier, ofType: "nib") != nil {
+            register(UINib(nibName: identifier, bundle: .main), forHeaderFooterViewReuseIdentifier: identifier)
+        } else {
+            register(headerFooterViewType, forHeaderFooterViewReuseIdentifier: identifier)
+        }
+    }
+
     /// Dequeues a reusable table view cell of type `CellType` which inherits from `UITableViewCell`.
     ///
     /// The class name of the `CellType` will be used as reuse identifier of the dequeued cell.
@@ -43,6 +66,24 @@ public extension UITableView {
     /// - Parameter indexPath: The index path for which the dequeue is intented to be.
     func dequeue<Cell: UITableViewCell>(cellOfType cellType: Cell.Type, for indexPath: IndexPath) -> Cell {
         return dequeueReusableCell(withIdentifier: String(describing: cellType), for: indexPath) as! Cell
+    }
+
+    /// Dequeues a reusable table view headerFooterView of type `HeaderFooterView` which inherits from `UITableViewHeaderFooterView`.
+    ///
+    /// The class name of the `HeaderFooterView` will be used as reuse identifier of the dequeued cell.
+    ///
+    /// Example:
+    /// ```swift
+    /// // The type of `headerFooterview` will be `MyHeaderFooterView`.
+    /// let headerFooter = tableView.dequeue(headerFooterViewOfType: MyHeaderFooterView.self)
+    /// ```
+    ///
+    /// - Attention: Always ensure that the registered headerFooterView is of type `HeaderFooterView`
+    ///              when the cell is not of type `HeaderFooterView` a crash will occure at runtime.
+    ///
+    /// - Parameter headerFooterViewType: The reusable headerFooterView type to be dequeued.
+    func dequeue<HeaderFooterView: UITableViewHeaderFooterView>(headerFooterViewOfType headerFooterViewType: HeaderFooterView.Type) -> HeaderFooterView {
+        return dequeueReusableHeaderFooterView(withIdentifier: String(describing: headerFooterViewType)) as! HeaderFooterView
     }
 }
 


### PR DESCRIPTION
- Implements base class for `TableViewHeaderFooterView`
- Implements `ContainerTableViewHeaderFooterView` working in a similar way as `ContainerTableViewCell`
- Implements recylcing methods for `UITableViewHeaderFooterView`s