### PR TITLE
Fix dispatch queue crash in BarcodeScanner module

### DIFF
--- a/Modules/BarcodeScanner/BarcodeScannerView.swift
+++ b/Modules/BarcodeScanner/BarcodeScannerView.swift
@@ -42,6 +42,8 @@ public final class BarcodeScannerView: StatefulView<BarcodeScannerViewModel> {
     private var isCaptureSessionConfigured: Bool = false
     private var isCaptureSessionRunning: Bool = false
 
+    private var isDeinited: Bool = false
+
     private var isScanningEnabled: Bool = false {
         didSet { didChangeState() }
     }
@@ -58,6 +60,12 @@ public final class BarcodeScannerView: StatefulView<BarcodeScannerViewModel> {
         didSet { didChangeState() }
     }
 
+    deinit {
+        // Resuming the capture session queue before release is mandatory to avoid crashes
+        isDeinited = true
+        captureSessionQueue.resume()
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -67,7 +75,7 @@ public final class BarcodeScannerView: StatefulView<BarcodeScannerViewModel> {
 
         captureSessionQueue.suspend()
         captureSessionQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let self = self, !self.isDeinited else { return }
 
             self.captureSession.beginConfiguration()
             defer { self.captureSession.commitConfiguration() }

--- a/Modules/BarcodeScanner/BarcodeScannerView.swift
+++ b/Modules/BarcodeScanner/BarcodeScannerView.swift
@@ -127,7 +127,7 @@ public final class BarcodeScannerView: StatefulView<BarcodeScannerViewModel> {
         super.didChangeModel()
 
         captureSessionQueue.async { [weak self] in
-            guard let self = self, self.isCaptureSessionConfigured else { return }
+            guard let self = self, self.isCaptureSessionConfigured, !self.isDeinited else { return }
 
             self.captureSession.beginConfiguration()
             defer { self.captureSession.commitConfiguration() }
@@ -158,7 +158,7 @@ public final class BarcodeScannerView: StatefulView<BarcodeScannerViewModel> {
     private func didChangeState() {
         if isScanning, isScanningEnabled, !isCaptureSessionRunning {
             self.captureSessionQueue.async { [weak self] in
-                guard let self = self else { return }
+                guard let self = self, !self.isDeinited else { return }
 
                 self.addObservers()
                 self.captureSession.startRunning()
@@ -168,7 +168,7 @@ public final class BarcodeScannerView: StatefulView<BarcodeScannerViewModel> {
 
         if (!isScanning || !isScanningEnabled), isCaptureSessionRunning {
             self.captureSessionQueue.async { [weak self] in
-                guard let self = self else { return }
+                guard let self = self, !self.isDeinited else { return }
 
                 self.captureSession.stopRunning()
                 self.isCaptureSessionRunning = self.captureSession.isRunning
@@ -271,7 +271,7 @@ public final class BarcodeScannerView: StatefulView<BarcodeScannerViewModel> {
     @objc
     private func captureDeviceSubjectAreaDidChange(_ notification: NSNotification) {
         captureSessionQueue.async { [weak self] in
-            guard let self = self, let device = self.captureDeviceInput?.device else { return }
+            guard let self = self, let device = self.captureDeviceInput?.device, !self.isDeinited else { return }
 
             do {
                 try device.lockForConfiguration()
@@ -303,7 +303,7 @@ public final class BarcodeScannerView: StatefulView<BarcodeScannerViewModel> {
         let error = AVError(_nsError: errorValue)
         if error.code == .mediaServicesWereReset {
             captureSessionQueue.async { [weak self] in
-                guard let self = self, self.isCaptureSessionRunning else { return }
+                guard let self = self, self.isCaptureSessionRunning, !self.isDeinited else { return }
 
                 self.captureSession.startRunning()
                 self.isCaptureSessionRunning = self.captureSession.isRunning


### PR DESCRIPTION
This PR fixes a crash in the BarcodeScanner module.

If the user didn't agree to the camera usage, the `captureSessionQueue` would have been left in suspended state forever. As it is illegal to release a `DispatchQueue` in suspended state, the barcode scanner would crash on deinitialization.

This PR fixes the issue by resuming the `captureSessionQueue` just before the deinitialization.