### PR TITLE
#56 Use key window instead of last window to present messageViews

### DIFF
--- a/Modules/MessageView/Presenter/MessageViewPresenter.swift
+++ b/Modules/MessageView/Presenter/MessageViewPresenter.swift
@@ -53,7 +53,7 @@ public final class MessageViewPresenter {
     }
 
     private func attach(messageView: MessageView) {
-        guard let window = UIApplication.shared.windows.last else { return }
+        guard let window = UIApplication.shared.windows.first(where: \.isKeyWindow) else { return }
 
         if messageView.model.appearanceConfiguration.shouldHaveBackgroundView {
             let backgroundView: UIView = .init(frame: window.bounds)


### PR DESCRIPTION
This PR is changing the selection on which window the messageView is displayed.

/closes #56 