### PR TITLE
Set number of lines to 0 on title label for DefaultCollapsibleHeaderView

### DIFF
--- a/Sources/Component/CollapsibleView/HeaderView/DefaultCollapsibleHeaderView.swift
+++ b/Sources/Component/CollapsibleView/HeaderView/DefaultCollapsibleHeaderView.swift
@@ -31,6 +31,7 @@ public final class DefaultCollapsibleHeaderView: StatefulView<DefaultCollapsible
         arrowImageViewHeightConstraint?.isActive = true
         arrowImageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10.0).isActive = true
 
+        titleLabel.numberOfLines = 0
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(titleLabel)
         titleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 16.0).isActive = true


### PR DESCRIPTION
This PR sets the number of lines for the default header view of collapsible view to 0 to be able to show multiple lines.