### PR TITLE
Set alignment of collapsible view to leading.

### DIFF
--- a/Sources/Component/CollapsibleView/CollapsibleView.swift
+++ b/Sources/Component/CollapsibleView/CollapsibleView.swift
@@ -45,7 +45,7 @@ public final class CollapsibleView<HeaderView: StatefulViewProtocol>: StatefulVi
 
     private lazy var stackView: UIStackView = {
         let stackView: UIStackView = .init()
-        stackView.alignment = .center
+        stackView.alignment = .leading
         stackView.axis = .vertical
         stackView.distribution = .fillProportionally
         return stackView


### PR DESCRIPTION
This PR fixes an issue on iPads where the items containing text where shown in the center but should be leading. 